### PR TITLE
code block with tab keyboard shortcut, see #116

### DIFF
--- a/docs/src/docPages/api/schema.md
+++ b/docs/src/docPages/api/schema.md
@@ -145,6 +145,17 @@ Node.create({
 })
 ```
 
+For some cases where you want features that aren’t available in marks, for example a node view, try if an inline node would work:
+
+```js
+Node.create({
+  name: 'customInlineNode',
+  group: 'inline',
+  inline: true,
+  content: 'text*',
+})
+```
+
 #### Atom
 Nodes with `atom: true` aren’t directly editable and should be treated as a single unit. It’s not so likely to use that in a editor context, but this is how it would look like:
 

--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -3,6 +3,10 @@ import { textblockTypeInputRule } from 'prosemirror-inputrules'
 
 export interface CodeBlockOptions {
   languageClassPrefix: string,
+  /**
+   * Whitespace for indentation (on Tab)
+   */
+  indentation: string,
   HTMLAttributes: {
     [key: string]: any
   },
@@ -16,6 +20,7 @@ export const CodeBlock = Node.create({
 
   defaultOptions: <CodeBlockOptions>{
     languageClassPrefix: 'language-',
+    indentation: '    ',
     HTMLAttributes: {},
   },
 
@@ -92,6 +97,9 @@ export const CodeBlock = Node.create({
   addKeyboardShortcuts() {
     return {
       'Mod-Alt-c': () => this.editor.commands.toggleCodeBlock(),
+      Tab: () => {
+        return this.editor.commands.insertText(this.options.indentation)
+      },
     }
   },
 


### PR DESCRIPTION
- [x] If nothing is selected, whitespace should be inserted.
- [ ] When something is selected, all touched lines (inside the code block) should be intended with whitespace.
- [ ] When Shift+Tab is pressed without a selection, the current line should be outdented.
- [ ] When Shift+Tab is pressed with an active selection, all touched lines (inside the code block) should be outdented.